### PR TITLE
Gitpodify

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full-vnc
+                    
+USER gitpod
+
+RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
+             && sdk install java 14.0.2.j9-adpt \
+             && sdk default java 14.0.2.j9-adpt"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: sdk use java 14.0.2.j9-adpt
+    command: mvn install
+
+ports:
+  # used by virtual desktop and vnc, supports JavaFX
+  - port: 6080

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/.theia/tasks.json
+++ b/.theia/tasks.json
@@ -1,0 +1,35 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "label": "run AccordionExample",
+            "type": "shell",
+            "command": "mvn exec:java -D\"exec.mainClass=com.jenkov.javafx.accordion.AccordionExample\"",
+            "group": "none",
+            "problemMatcher": []
+        },
+        {
+            "label": "run AnimationExample",
+            "type": "shell",
+            "command": "mvn exec:java -D\"exec.mainClass=com.jenkov.javafx.animation.AnimationExample\"",
+            "group": "none",
+            "problemMatcher": []
+        },
+        {
+            "label": "run ButtonExample",
+            "type": "shell",
+            "command": "mvn exec:java -D\"exec.mainClass=com.jenkov.javafx.button.ButtonExample\"",
+            "group": "none",
+            "problemMatcher": []
+        },
+        {
+            "label": "run DisabledButtonExample",
+            "type": "shell",
+            "command": "mvn exec:java -D\"exec.mainClass=com.jenkov.javafx.button.DisabledButtonExample\"",
+            "group": "none",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/jjenkov/javafx-examples)
+
 # JavaFX Examples
 This repository contains a growing collection of JavaFX examples. I am converting existing examples from my
 own hard drive, but I need to clean each example up before I am able to share it. I have somewhere between 50 and 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.jenkov</groupId>
+    <artifactId>javafx-examples</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-fxml -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>14.0.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <release>14</release>
+                    <compilerArgs>
+                        <!-- 
+                            <arg>dash dash enable-preview</arg>
+                        -->
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,15 @@
     </properties>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-fxml -->
+        <!-- https://mvnrepository.com/artifact/org.openjfx -->
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
+            <version>14.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-web</artifactId>
             <version>14.0.2</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
It would be great to be able to run the examples in gitpod, thus removing the need to install anything. This PR adds a gitpod configuration that installs and uses Java 14 and makes (a couple of) the examples runnable as task from Terminal > Task ...

I haven't changed the README to describe how to run in gitpod, but can do that if you think supporting gitpod is a good idea.